### PR TITLE
ci: disable persist-credentials in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - run: ci/set_rust_version.bash ${{ matrix.channel }} ${{ matrix.target }}
         shell: bash
       - run: ci/test.bash cargo ${{ matrix.target }}


### PR DESCRIPTION
We already do this in most of the other Rustls crates, and Zizmor 0.7.0 [flags its absence](https://woodruffw.github.io/zizmor/audits/#artipacked) in this repo. As mentioned in the description of this finding:

> By default, using [actions/checkout](https://github.com/actions/checkout) causes a credential to be persisted in the checked-out repo's .git/config, so that subsequent git operations can be authenticated.
> 
> Subsequent steps may accidentally publicly persist .git/config, e.g. by including it in a publicly accessible artifact via [actions/upload-artifact](https://github.com/actions/upload-artifact).
>
> However, even without this, persisting the credential in the .git/config is non-ideal unless actually needed.

We don't need it, so turn it off :-) It's a bad default!